### PR TITLE
Prepare 0.0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Hackage](https://img.shields.io/hackage/v/regex.svg)](https://hackage.haskell.org/package/regex)
 [![BSD3 License](http://img.shields.io/badge/license-BSD3-brightgreen.svg)](https://tldrlegal.com/license/bsd-3-clause-license-%28revised%29)
-[![Un*x build](https://img.shields.io/travis/iconnect/regex.svg?label=Linux%2FmacOS)](https://travis-ci.org/iconnect/regex)
+[![Un*x build](https://img.shields.io/travis/iconnect/regex.svg?label=Linux%2BmacOS)](https://travis-ci.org/iconnect/regex)
 [![Windows build](https://img.shields.io/appveyor/ci/engineerirngirisconnectcouk/regex.svg?label=Windows)](https://ci.appveyor.com/project/engineerirngirisconnectcouk/regex/branch/master)
 [![Coverage](https://img.shields.io/coveralls/iconnect/regex.svg)](https://coveralls.io/github/iconnect/regex?branch=master)
 
@@ -25,10 +25,11 @@ regex extends regex-base with:
 Schedule
 --------
 
-  * **2017-01-27**&nbsp;&nbsp;0.0.0.1&nbsp;&nbsp;Pre-release
-  * **2017-01-30**&nbsp;&nbsp;0.0.1.0&nbsp;&nbsp;RFC
-  * **2017-02-20**&nbsp;&nbsp;0.1.0.0&nbsp;&nbsp;a candidate stable release
-  * **2017-03-20**&nbsp;&nbsp;1.0.0.0&nbsp;&nbsp;first stable release
+- [X] **2017-01-26**&nbsp;&nbsp;0.0.0.1&nbsp;&nbsp;Pre-release (I)
+- [X] **2017-01-30**&nbsp;&nbsp;0.0.0.2&nbsp;&nbsp;Pre-release (II)
+- [ ] **2017-02-06**&nbsp;&nbsp;0.0.1.0&nbsp;&nbsp;RFC
+- [ ] **2017-02-20**&nbsp;&nbsp;0.1.0.0&nbsp;&nbsp;a candidate stable release
+- [ ] **2017-03-20**&nbsp;&nbsp;1.0.0.0&nbsp;&nbsp;first stable release
 
 
 The Web Page

--- a/Text/RE/PCRE/ByteString.hs
+++ b/Text/RE/PCRE/ByteString.hs
@@ -20,16 +20,19 @@ import           Text.RE.PCRE.RE
 import qualified Text.Regex.PCRE               as PCRE
 
 
+-- | find all matches in text
 (*=~) :: B.ByteString
       -> RE
       -> Matches B.ByteString
 (*=~) bs rex = addCaptureNamesToMatches (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | find first matches in text
 (?=~) :: B.ByteString
       -> RE
       -> Match B.ByteString
 (?=~) bs rex = addCaptureNamesToMatch (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | regex-base polymorphic match operator
 (=~) :: ( RegexContext PCRE.Regex B.ByteString a
         , RegexMaker   PCRE.Regex PCRE.CompOption PCRE.ExecOption String
         )
@@ -38,6 +41,7 @@ import qualified Text.Regex.PCRE               as PCRE
      -> a
 (=~) bs rex = match (reRegex rex) bs
 
+-- | regex-base monadic, polymorphic match operator
 (=~~) :: ( Monad m
          , RegexContext PCRE.Regex B.ByteString a
          , RegexMaker   PCRE.Regex PCRE.CompOption PCRE.ExecOption String

--- a/Text/RE/PCRE/ByteString/Lazy.hs
+++ b/Text/RE/PCRE/ByteString/Lazy.hs
@@ -20,16 +20,19 @@ import           Text.RE.PCRE.RE
 import qualified Text.Regex.PCRE               as PCRE
 
 
+-- | find all matches in text
 (*=~) :: LBS.ByteString
       -> RE
       -> Matches LBS.ByteString
 (*=~) bs rex = addCaptureNamesToMatches (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | find first matches in text
 (?=~) :: LBS.ByteString
       -> RE
       -> Match LBS.ByteString
 (?=~) bs rex = addCaptureNamesToMatch (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | regex-base polymorphic match operator
 (=~) :: ( RegexContext PCRE.Regex LBS.ByteString a
         , RegexMaker   PCRE.Regex PCRE.CompOption PCRE.ExecOption String
         )
@@ -38,6 +41,7 @@ import qualified Text.Regex.PCRE               as PCRE
      -> a
 (=~) bs rex = match (reRegex rex) bs
 
+-- | regex-base monadic, polymorphic match operator
 (=~~) :: ( Monad m
          , RegexContext PCRE.Regex LBS.ByteString a
          , RegexMaker   PCRE.Regex PCRE.CompOption PCRE.ExecOption String

--- a/Text/RE/PCRE/Sequence.hs
+++ b/Text/RE/PCRE/Sequence.hs
@@ -20,16 +20,19 @@ import           Text.RE.PCRE.RE
 import qualified Text.Regex.PCRE               as PCRE
 
 
+-- | find all matches in text
 (*=~) :: (S.Seq Char)
       -> RE
       -> Matches (S.Seq Char)
 (*=~) bs rex = addCaptureNamesToMatches (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | find first matches in text
 (?=~) :: (S.Seq Char)
       -> RE
       -> Match (S.Seq Char)
 (?=~) bs rex = addCaptureNamesToMatch (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | regex-base polymorphic match operator
 (=~) :: ( RegexContext PCRE.Regex (S.Seq Char) a
         , RegexMaker   PCRE.Regex PCRE.CompOption PCRE.ExecOption String
         )
@@ -38,6 +41,7 @@ import qualified Text.Regex.PCRE               as PCRE
      -> a
 (=~) bs rex = match (reRegex rex) bs
 
+-- | regex-base monadic, polymorphic match operator
 (=~~) :: ( Monad m
          , RegexContext PCRE.Regex (S.Seq Char) a
          , RegexMaker   PCRE.Regex PCRE.CompOption PCRE.ExecOption String

--- a/Text/RE/PCRE/String.hs
+++ b/Text/RE/PCRE/String.hs
@@ -20,16 +20,19 @@ import           Text.RE.PCRE.RE
 import qualified Text.Regex.PCRE               as PCRE
 
 
+-- | find all matches in text
 (*=~) :: String
       -> RE
       -> Matches String
 (*=~) bs rex = addCaptureNamesToMatches (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | find first matches in text
 (?=~) :: String
       -> RE
       -> Match String
 (?=~) bs rex = addCaptureNamesToMatch (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | regex-base polymorphic match operator
 (=~) :: ( RegexContext PCRE.Regex String a
         , RegexMaker   PCRE.Regex PCRE.CompOption PCRE.ExecOption String
         )
@@ -38,6 +41,7 @@ import qualified Text.Regex.PCRE               as PCRE
      -> a
 (=~) bs rex = match (reRegex rex) bs
 
+-- | regex-base monadic, polymorphic match operator
 (=~~) :: ( Monad m
          , RegexContext PCRE.Regex String a
          , RegexMaker   PCRE.Regex PCRE.CompOption PCRE.ExecOption String

--- a/Text/RE/TDFA/ByteString.hs
+++ b/Text/RE/TDFA/ByteString.hs
@@ -20,16 +20,19 @@ import           Text.RE.TDFA.RE
 import qualified Text.Regex.TDFA               as TDFA
 
 
+-- | find all matches in text
 (*=~) :: B.ByteString
       -> RE
       -> Matches B.ByteString
 (*=~) bs rex = addCaptureNamesToMatches (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | find first matches in text
 (?=~) :: B.ByteString
       -> RE
       -> Match B.ByteString
 (?=~) bs rex = addCaptureNamesToMatch (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | regex-base polymorphic match operator
 (=~) :: ( RegexContext TDFA.Regex B.ByteString a
         , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String
         )
@@ -38,6 +41,7 @@ import qualified Text.Regex.TDFA               as TDFA
      -> a
 (=~) bs rex = match (reRegex rex) bs
 
+-- | regex-base monadic, polymorphic match operator
 (=~~) :: ( Monad m
          , RegexContext TDFA.Regex B.ByteString a
          , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String

--- a/Text/RE/TDFA/ByteString/Lazy.hs
+++ b/Text/RE/TDFA/ByteString/Lazy.hs
@@ -20,16 +20,19 @@ import           Text.RE.TDFA.RE
 import qualified Text.Regex.TDFA               as TDFA
 
 
+-- | find all matches in text
 (*=~) :: LBS.ByteString
       -> RE
       -> Matches LBS.ByteString
 (*=~) bs rex = addCaptureNamesToMatches (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | find first matches in text
 (?=~) :: LBS.ByteString
       -> RE
       -> Match LBS.ByteString
 (?=~) bs rex = addCaptureNamesToMatch (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | regex-base polymorphic match operator
 (=~) :: ( RegexContext TDFA.Regex LBS.ByteString a
         , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String
         )
@@ -38,6 +41,7 @@ import qualified Text.Regex.TDFA               as TDFA
      -> a
 (=~) bs rex = match (reRegex rex) bs
 
+-- | regex-base monadic, polymorphic match operator
 (=~~) :: ( Monad m
          , RegexContext TDFA.Regex LBS.ByteString a
          , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String

--- a/Text/RE/TDFA/Sequence.hs
+++ b/Text/RE/TDFA/Sequence.hs
@@ -20,16 +20,19 @@ import           Text.RE.TDFA.RE
 import qualified Text.Regex.TDFA               as TDFA
 
 
+-- | find all matches in text
 (*=~) :: (S.Seq Char)
       -> RE
       -> Matches (S.Seq Char)
 (*=~) bs rex = addCaptureNamesToMatches (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | find first matches in text
 (?=~) :: (S.Seq Char)
       -> RE
       -> Match (S.Seq Char)
 (?=~) bs rex = addCaptureNamesToMatch (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | regex-base polymorphic match operator
 (=~) :: ( RegexContext TDFA.Regex (S.Seq Char) a
         , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String
         )
@@ -38,6 +41,7 @@ import qualified Text.Regex.TDFA               as TDFA
      -> a
 (=~) bs rex = match (reRegex rex) bs
 
+-- | regex-base monadic, polymorphic match operator
 (=~~) :: ( Monad m
          , RegexContext TDFA.Regex (S.Seq Char) a
          , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String

--- a/Text/RE/TDFA/String.hs
+++ b/Text/RE/TDFA/String.hs
@@ -20,16 +20,19 @@ import           Text.RE.TDFA.RE
 import qualified Text.Regex.TDFA               as TDFA
 
 
+-- | find all matches in text
 (*=~) :: String
       -> RE
       -> Matches String
 (*=~) bs rex = addCaptureNamesToMatches (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | find first matches in text
 (?=~) :: String
       -> RE
       -> Match String
 (?=~) bs rex = addCaptureNamesToMatch (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | regex-base polymorphic match operator
 (=~) :: ( RegexContext TDFA.Regex String a
         , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String
         )
@@ -38,6 +41,7 @@ import qualified Text.Regex.TDFA               as TDFA
      -> a
 (=~) bs rex = match (reRegex rex) bs
 
+-- | regex-base monadic, polymorphic match operator
 (=~~) :: ( Monad m
          , RegexContext TDFA.Regex String a
          , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String

--- a/Text/RE/TDFA/Text.hs
+++ b/Text/RE/TDFA/Text.hs
@@ -20,16 +20,19 @@ import           Text.RE.TDFA.RE
 import qualified Text.Regex.TDFA               as TDFA
 
 
+-- | find all matches in text
 (*=~) :: T.Text
       -> RE
       -> Matches T.Text
 (*=~) bs rex = addCaptureNamesToMatches (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | find first matches in text
 (?=~) :: T.Text
       -> RE
       -> Match T.Text
 (?=~) bs rex = addCaptureNamesToMatch (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | regex-base polymorphic match operator
 (=~) :: ( RegexContext TDFA.Regex T.Text a
         , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String
         )
@@ -38,6 +41,7 @@ import qualified Text.Regex.TDFA               as TDFA
      -> a
 (=~) bs rex = match (reRegex rex) bs
 
+-- | regex-base monadic, polymorphic match operator
 (=~~) :: ( Monad m
          , RegexContext TDFA.Regex T.Text a
          , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String

--- a/Text/RE/TDFA/Text/Lazy.hs
+++ b/Text/RE/TDFA/Text/Lazy.hs
@@ -20,16 +20,19 @@ import           Text.RE.TDFA.RE
 import qualified Text.Regex.TDFA               as TDFA
 
 
+-- | find all matches in text
 (*=~) :: TL.Text
       -> RE
       -> Matches TL.Text
 (*=~) bs rex = addCaptureNamesToMatches (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | find first matches in text
 (?=~) :: TL.Text
       -> RE
       -> Match TL.Text
 (?=~) bs rex = addCaptureNamesToMatch (reCaptureNames rex) $ match (reRegex rex) bs
 
+-- | regex-base polymorphic match operator
 (=~) :: ( RegexContext TDFA.Regex TL.Text a
         , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String
         )
@@ -38,6 +41,7 @@ import qualified Text.Regex.TDFA               as TDFA
      -> a
 (=~) bs rex = match (reRegex rex) bs
 
+-- | regex-base monadic, polymorphic match operator
 (=~~) :: ( Monad m
          , RegexContext TDFA.Regex TL.Text a
          , RegexMaker   TDFA.Regex TDFA.CompOption TDFA.ExecOption String

--- a/changelog
+++ b/changelog
@@ -5,7 +5,7 @@
   * Remove hsyslog dependency
   * Establish Travis CI, AppVeyor and coveralls.io integrations
   * Fix time parser to use Fixed arithmetic
-  * Miscelaneous fixes
+  * Miscelaneous minor adjustments
 
 0.0.0.1 Chris Dornan <chris.dornan@irisconnect.co.uk> 2017-01-26
 	* First public release

--- a/changelog
+++ b/changelog
@@ -1,4 +1,11 @@
 -*-change-log-*-
 
-0.0.0.1 Chris Dornan <chrisd@irisconnect.co.uk> Feb 2014
+0.0.0.2 Chris Dornan <chris.dornan@irisconnect.co.uk> 2017-01-30
+  * Fix for Windows
+  * Remove hsyslog dependency
+  * Establish Travis CI, AppVeyor and coveralls.io integrations
+  * Fix time parser to use Fixed arithmetic
+  * Miscelaneous fixes
+
+0.0.0.1 Chris Dornan <chris.dornan@irisconnect.co.uk> 2017-01-26
 	* First public release

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,10 +22,11 @@ regex extends regex-base with:
 Schedule
 --------
 
-  * **2017-01-27**&nbsp;&nbsp;0.0.0.1&nbsp;&nbsp;Pre-release
-  * **2017-01-30**&nbsp;&nbsp;0.0.1.0&nbsp;&nbsp;RFC
-  * **2017-02-20**&nbsp;&nbsp;0.1.0.0&nbsp;&nbsp;a candidate stable release
-  * **2017-03-20**&nbsp;&nbsp;1.0.0.0&nbsp;&nbsp;first stable release
+- [X] **2017-01-26**&nbsp;&nbsp;0.0.0.1&nbsp;&nbsp;Pre-release (I)
+- [X] **2017-01-30**&nbsp;&nbsp;0.0.0.2&nbsp;&nbsp;Pre-release (II)
+- [ ] **2017-02-06**&nbsp;&nbsp;0.0.1.0&nbsp;&nbsp;RFC
+- [ ] **2017-02-20**&nbsp;&nbsp;0.1.0.0&nbsp;&nbsp;a candidate stable release
+- [ ] **2017-03-20**&nbsp;&nbsp;1.0.0.0&nbsp;&nbsp;first stable release
 
 
 Installation Instructions

--- a/regex.cabal
+++ b/regex.cabal
@@ -1,5 +1,5 @@
 Name:                   regex
-Version:                0.0.0.1
+Version:                0.0.0.2
 Synopsis:               A Regular Expression Toolkit for regex-base
 Description:            A Regular Expression Toolkit for regex-base with
                         Compile-time checking of RE syntax, data types for
@@ -16,8 +16,11 @@ Copyright:              Chris Dornan 2016-2017
 Category:               Text
 Build-type:             Simple
 Stability:              rfc
-Extra-source-files:     changelog
 bug-reports:            https://github.com/iconnect/regex/issues
+
+extra-source-files:
+    README.md
+    changelog
 
 Cabal-version:          >= 1.16
 
@@ -26,9 +29,9 @@ Source-repository head
     location:           https://github.com/iconnect/regex.git
 
 Source-Repository this
-    Type:              git
-    Location:          https://github.com/iconnect/regex.git
-    Tag:               0.0.0.1
+    Type:               git
+    Location:           https://github.com/iconnect/regex.git
+    Tag:                0.0.0.2
 
 Library
     Exposed-modules:


### PR DESCRIPTION
Update to Hackage of this weekend's fixes.

From the changelog:

```
0.0.0.2 Chris Dornan <chris.dornan@irisconnect.co.uk> 2017-01-30
  * Fix for Windows
  * Remove hsyslog dependency
  * Establish Travis CI, AppVeyor and coveralls.io integrations
  * Fix time parser to use Fixed arithmetic
  * Miscelaneous minor adjustments
```
